### PR TITLE
Fix including lasso flags when loading prebuild bundles

### DIFF
--- a/taglib/slot-tag.js
+++ b/taglib/slot-tag.js
@@ -58,6 +58,8 @@ module.exports = function render (input, out) {
 
   const templatePath = template && template.path;
   const lassoConfig = lassoRenderContext.getLassoConfig();
+  const pageConfig = lassoRenderContext.data.config || {};
+  pageConfig.flags = pageConfig.flags || out.global.flags || [];
 
   if (lassoConfig.getLoadPrebuild && templatePath && lassoConfig.getLoadPrebuild()) {
     lassoRenderContext.emitBeforeSlot(slotName, out);
@@ -71,7 +73,7 @@ module.exports = function render (input, out) {
 
     const prebuildPath = getPrebuildPath(templatePath);
 
-    lasso.loadPrebuild({ path: prebuildPath })
+    lasso.loadPrebuild({ path: prebuildPath, flags: pageConfig.flags })
       .then((lassoPageResult) => {
         renderSlot(input, lassoPageResult, asyncOut, lassoRenderContext);
         asyncOut.end();
@@ -83,8 +85,6 @@ module.exports = function render (input, out) {
   }
 
   if (!lassoPageResultAsyncValue) {
-    var pageConfig = lassoRenderContext.data.config || {};
-
     if (!templateHasMetaDeps && !pageConfig.dependencies && !pageConfig.packagePaths) {
       throw new Error('Lasso page result not found for slot "' + slotName + '". The <lasso-page> tag should be used to lasso the page.');
     }
@@ -113,7 +113,6 @@ module.exports = function render (input, out) {
     pageConfig.cacheKey = pageConfig.cacheKey || templatePath;
     pageConfig.dirname = pageConfig.dirname || (template && path.dirname(template.path));
     pageConfig.filename = pageConfig.filename || templatePath;
-    pageConfig.flags = pageConfig.flags || out.global.flags || [];
 
     lassoPageTag(pageConfig, out);
 

--- a/test/autotests/taglib/attrs/expected.marko
+++ b/test/autotests/taglib/attrs/expected.marko
@@ -8,7 +8,7 @@
 </style>
     </head>
     <body>
-        <script my-custom src="/static/taglib-attrs-7a917c02.js"></script>
+        <script my-custom src="/static/taglib-attrs-36336bf8.js"></script>
 <script>$_mod.ready();</script>
         <script my-custom src="/static/taglib-attrs-c3a331b0.js"></script>
         <script my-custom>console.log('hello-inline');

--- a/test/autotests/taglib/csp-nonce/expected.marko
+++ b/test/autotests/taglib/csp-nonce/expected.marko
@@ -12,7 +12,7 @@
     </head>
     <body>
         <script foo="bar" nonce="abc">console.log('my inline script');</script>
-        <script src="/static/taglib-csp-nonce-087d89b8.js"></script>
+        <script src="/static/taglib-csp-nonce-b6883da9.js"></script>
 <script nonce="abc">$_mod.ready();</script>
     </body>
 </html>

--- a/test/autotests/taglib/global-dependencies/expected.marko
+++ b/test/autotests/taglib/global-dependencies/expected.marko
@@ -3,7 +3,7 @@
         <link rel="stylesheet" href="/static/taglib-global-dependencies-1ae3e9bf.css">
     </head>
     <body>
-        <script src="/static/taglib-global-dependencies-682ebe7d.js"></script>
+        <script src="/static/taglib-global-dependencies-ee19c31b.js"></script>
 <script>$_mod.ready();</script>
     </body>
 </html>

--- a/test/autotests/taglib/simple/expected.marko
+++ b/test/autotests/taglib/simple/expected.marko
@@ -11,7 +11,7 @@
     <body>
         <img src="/static/marko-logo-314d77d4.png" width=240 height=200>
         <img src="/static/marko-logo-314d77d4.png" width="100" height="100">
-        <script src="/static/taglib-simple-55b26022.js"></script>
+        <script src="/static/taglib-simple-d5ba7b47.js"></script>
 <script>$_mod.ready();</script>
     </body>
 </html>


### PR DESCRIPTION
Currently when loading prebuild bundles from lasso it never passes along the flags provided lasso flags. This change ensures that they are included.

The tests also had different hashes for some reason (unrelated to this change, perhaps a dep change) and so I updated those as well.