### PR TITLE
Fixed a deprecation warning about "path" attribute type

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -5,7 +5,7 @@
       "attributes":{
         "name":"string",
         "cache-key":"string",
-        "package-path":"path",
+        "package-path":"string",
         "package-paths":"array",
         "base-path":"string",
         "lasso":"lasso/Lasso",

--- a/marko.json
+++ b/marko.json
@@ -89,7 +89,7 @@
     "lasso-img":{
       "code-generator":"./taglib/lasso-img-tag",
       "attributes":{
-        "src":"path",
+        "src":"string",
         "*":{
           "ignore":true
         }
@@ -117,7 +117,7 @@
       "transformer":"./taglib/lasso-resource-tag-transform",
       "no-output":true,
       "attributes":{
-        "path":"path",
+        "path":"string",
         "var":"string"
       },
       "autocomplete":[


### PR DESCRIPTION
Marko Taglib deprecated the attribute type which was "path".
Now it's standardized to use "string" also for paths.

The deprecation warning doesn't appear again.

I just changed the "path" types to "string" ones.
Everything works fine.