### PR TITLE
Fixed two deprecations warning, about "path" attribute type and default "target-property" in Marko Taglib

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -5,7 +5,7 @@
       "attributes":{
         "name":"string",
         "cache-key":"string",
-        "package-path":"path",
+        "package-path":"string",
         "package-paths":"array",
         "base-path":"string",
         "lasso":"lasso/Lasso",

--- a/marko.json
+++ b/marko.json
@@ -89,7 +89,7 @@
     "lasso-img":{
       "code-generator":"./taglib/lasso-img-tag",
       "attributes":{
-        "src":"path",
+        "src":"string",
         "*":{
           "ignore":true
         }
@@ -117,7 +117,7 @@
       "transformer":"./taglib/lasso-resource-tag-transform",
       "no-output":true,
       "attributes":{
-        "path":"path",
+        "path":"string",
         "var":"string"
       },
       "autocomplete":[


### PR DESCRIPTION
Marko Taglib deprecated the attribute type which was "path".
Now it's standardized to use "string" also for paths.
I just changed the "path" types to "string" ones.
There also was another deprecation warning which was about "*" attributes: the default "target-property" will not be "*" anymore but null in the future, so it needs to explicitly be declared. I did so, in the two "*" attributes.

The deprecation warning doesn't appear again.
Everything works fine.